### PR TITLE
Make bash code example robust with `set -u`

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@ print(config_dir)</pre
 get_config_dir() {
   unset REPLY; REPLY=
 
-  local config_dir="$XDG_CONFIG_HOME"
+  local config_dir="${XDG_CONFIG_HOME-}"
 
   # If the value of the environment variable is unset, empty or not an absolute path, use the default
   if [ -z "$config_dir" ] || [ "${config_dir::1}" != '/' ]; then


### PR DESCRIPTION
Often shell scripts have stanzas like

```bash
set -euo pipefail
```

to make unexpected behavior error rather than silently continue execution.

In particular, `set -u` errors whenever there is an unset variable, which causes the lookup

https://github.com/fox-projects/xdgbasedirectoryspecification.com/blob/0d1ff933d0f8c36259e870d2e421b0c33b29e26c/index.html#L472

to fail. This can be fixed by using [parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) to turn the unset case into the empty case, which is handled after.

https://github.com/fox-projects/xdgbasedirectoryspecification.com/blob/0d1ff933d0f8c36259e870d2e421b0c33b29e26c/index.html#L474-L478

This issue was first brought to my attention by https://github.com/eshrh/ames/issues/11 and this fix was proposed by @arbyste in https://github.com/eshrh/ames/pull/12.